### PR TITLE
reflectable < 0.4.0 support added, < 0.1.5 is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * add more tests
 
+# Version 0.0.6
+
+* reflectable < 0.4.0 support added, < 0.1.5 is not supported
+
 # Version 0.0.5+2
 
 * extend version support of reflectable package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: drails_commons
-version: 0.0.5+2
+version: 0.0.6
 author: Luis Vargas <luisvargastijerino@gmail.com>
 description: Package that contains some utilities classes, methods, and global constants shared by drails, drails_di, and dson.
 homepage: https://github.com/luisvt/drails_commons
 environment:
   sdk: '>=1.8.0'
 dependencies:
-  reflectable: '>=0.1.0 <0.3.0'
+  reflectable: '>=0.1.5 <0.4.0'
 #  reflectable:
 #    path: ../reflectable/reflectable
 dev_dependencies:

--- a/test/GetPublicVariablesAndGetters_test.dart
+++ b/test/GetPublicVariablesAndGetters_test.dart
@@ -9,6 +9,7 @@ const myReflectable = const MyReflectable();
 
 class MyReflectable extends  Reflectable {
   const MyReflectable() : super(
+      superclassQuantifyCapability,
       invokingCapability,
       metadataCapability,
       typeCapability,


### PR DESCRIPTION
All tests are passed, not sure if there enough of them
